### PR TITLE
Add file-readable-p to the list of cached results for tramp vc-regist…

### DIFF
--- a/lisp/net/tramp-sh.el
+++ b/lisp/net/tramp-sh.el
@@ -3735,10 +3735,11 @@ Fall back to normal file name handler if no Tramp handler exists."
 	    (cond
 	     ;; That's what we want: file names, for which checks are
 	     ;; applied.  We assume that VC uses only `file-exists-p'
-	     ;; and `file-readable-p' checks; otherwise we must extend
-	     ;; the list.  We do not perform any action, but return
-	     ;; nil, in order to keep `vc-registered' running.
-	     ((and fn (memq operation '(file-exists-p file-readable-p)))
+	     ;; `file-readable-p' and 'file-directory-p' checks;
+	     ;;	otherwise we must extend the list.  We do not perform 
+	     ;;	any action, but return nil, in order to keep `vc-registered'
+	     ;;	running.
+	     ((and fn (memq operation '(file-exists-p file-readable-p file-directory-p)))
 	      (add-to-list 'tramp-vc-registered-file-names localname 'append)
 	      nil)
 	     ;; `process-file' and `start-file-process' shall be ignored.


### PR DESCRIPTION
…ered

[The function `tramp-vc-file-name-handler` temporarily patches a handler so that when `vc-registered` is run, tramp can remember on which files `vc-registered` tried to run `file-exists-p` or `file-readable-p` will run.](https://github.com/emacs-mirror/emacs/blob/2a6af880b0958d527a4d32005ef9acf3bc4ea030/lisp/net/tramp-sh.el#L3658)  For those remembered files, nothing is run.  For all other commands on the files that tramp usually intercepts, it will run them normally.

After that, [`tramp-bundle-read-file-names`](https://github.com/emacs-mirror/emacs/blob/2a6af880b0958d527a4d32005ef9acf3bc4ea030/lisp/net/tramp-sh.el#L3667) is used to get all the `exists` and `readable` information of those files in a single ssh command rather than the multiple commands that would have been needed without the caching.

Finally, tramp then restores the handle and runs `vc-registered` again, this time to return the real results from the cache.

All this is efficient if `vc-registered` only needs the `file-exists-p` and `file-readable-p`, [as described](https://github.com/emacs-mirror/emacs/blob/2a6af880b0958d527a4d32005ef9acf3bc4ea030/lisp/net/tramp-sh.el#L3736-L3740).  However, by setting `debug-on-entry` on `tramp-run-test` and performing a `revert-buffer-quick` on a buffer that is visiting a tramp file in a git directory, the backtrace shows that `vc-registred` is actually calling `file-directory-p` many times!

```
* tramp-run-test
  tramp-sh-handle-file-directory-p
  tramp-vc-file-name-handler
  locate-dominating-file
  vc-find-root
  vc-svn-registered
  vc-call-backend
  #f(compiled-function (b) #<bytecode 0x1f8e4c95fca59c10>)(SVN)
  mapc(#f(compiled-function (b) #<bytecode 0x1f8e4c95fca59c10>) (RCS CVS SVN SCCS SRC Bzr Git Hg))
  vc-registered
  apply(vc-registered ...)
  tramp-run-real-handler(vc-registered ...)
  tramp-sh-handle-vc-registered
  tramp-sh-file-name-handler
  apply(tramp-sh-file-name-handler ...)
  tramp-file-name-handler(vc-registered ...)
  vc-registered(...)
```

Typing `c` to step through the debugger many times, we see that `tramp-run-test` is called once per element in the path of the file being reverted.  We would prefer this to be cached!

Fortunately, the cache already stores the answer for the output of `file-directory-p`.  So we don't have to change the data in the cache, we just need to update the list of functions that are cached to include `file-directory-p`.

To see the results, `set-variable` `tramp-verbose` to `6` and watch the debug buffer during a `revert-buffer-quick` of a file over tramp.  Instead of many `tramp-send-command` sending `test -d` and then a `tramp_bundle_read_file_names`, there will just be a single `tramp_bundle_read_file_names`.  This runs faster.